### PR TITLE
Split Emu from UI specific DOM elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/deploy/index.html
+++ b/src/deploy/index.html
@@ -17,6 +17,7 @@
     <script src="js/osint.js" type="text/javascript"></script>
     <script src="js/vector_t.js" type="text/javascript"></script>
     <script src="js/vecx.js" type="text/javascript"></script>
+    <script src="js/input.js" type="text/javascript"></script>
 
     <script src="js/roms/castle.js" type="text/javascript"></script>
 
@@ -146,18 +147,18 @@
 
             if (file) {
                 if (file.size <= 100 * 1024) /* 100kb max */ {
-                    var reader = new FileReader();  
+                    var reader = new FileReader();
                     reader.readAsBinaryString(file);
                     $("#status").text("Processing file...");
-                     reader.onloadend = function() {            
-                        $("#status").text("Processing completed.");                                 
-                        Globals.cartdata = reader.result;                                         
+                     reader.onloadend = function() {
+                        $("#status").text("Processing completed.");
+                        Globals.cartdata = reader.result;
                         $("#roms").val("");
                         switchRom([null, null, "none", "none"]);
-                    }                   
+                    }
                 } else {
                     $("#status").text("File too large.");
-                }                
+                }
             }
         }
 
@@ -268,6 +269,7 @@
                 }
             );
 
+            /* input.js
             document.onkeydown =
                 function(event) {
                     vecx.onkeydown(event)
@@ -277,7 +279,7 @@
                 function(event) {
                     vecx.onkeyup(event)
                 };
-
+            */
             /*
             document.onkeypress =
                 function( event )
@@ -350,8 +352,13 @@
                 event.preventDefault();
             });
 
+            // DrSnuggles: added canvas parameter
+            vecx.main( $('#screen')[0] );
 
-            vecx.main();
+            // DrSnuggles: poll status from vecx
+            setInterval(function(){
+              $("#status").text( vecx.status );
+            }, 2000);
         });
     </script>
 </head>

--- a/src/deploy/js/input.js
+++ b/src/deploy/js/input.js
@@ -1,0 +1,90 @@
+/*
+  input.js
+  maps inputs from various sources to vecx.js
+  - keyboard
+*/
+
+var input = (function() {
+  var my = {};
+
+  //
+  // keyboard
+  //
+  my.keys = (function() {
+    var my = {
+      'switchKeys' : false, // false := keyboard is used for player one
+    };
+    var pressed = [
+      {"left":false, "right":false, "up":false, "down":false},
+      {"left":false, "right":false, "up":false, "down":false}
+    ];
+    var keyHandler = function(e) {
+      var handled = true;
+      var held = (e.type == "keydown"); // which event keyup or -down
+      var controller = my.switchKeys ? 1 : 0;
+      switch( e.keyCode ) {
+        case 37:
+        case 76: // left
+          pressed[controller].left = held;
+          break;
+        case 38:
+        case 80: // up
+          pressed[controller].up = held;
+          break;
+        case 39:
+        case 222: // right
+          pressed[controller].right = held;
+          break;
+        case 40:
+        case 59:
+        case 186: // down
+          pressed[controller].down = held;
+          break;
+        case 65: // a
+          vecx.button(controller, 0, held);
+          break;
+        case 83: // s
+          vecx.button(controller, 1, held);
+          break;
+        case 68: // d
+          vecx.button(controller, 2, held);
+          break;
+        case 70: // f
+          vecx.button(controller, 3, held);
+          break;
+        default:
+        handled = false;
+      }
+
+      // send axis to vecx
+      for (var i = 0; i < pressed.length; i++) {
+        if (pressed[i].left) {
+          vecx.axis(i, 0, 0x00);
+        } else if (pressed[i].right) {
+          vecx.axis(i, 0, 0xFF);
+        } else {
+          vecx.axis(i, 0, 0x80);
+        }
+        if (pressed[i].down) {
+          vecx.axis(i, 1, 0x00);
+        } else if (pressed[i].up) {
+          vecx.axis(i, 1, 0xFF);
+        } else {
+          vecx.axis(i, 1, 0x80);
+        }
+      }
+
+      if( handled && e.preventDefault ) {
+        e.preventDefault();
+      }
+
+    };
+
+    addEventListener("keydown", keyHandler, false);
+    addEventListener("keyup", keyHandler, false);
+
+    return my;
+  })();
+
+  return my;
+})();

--- a/src/deploy/js/osint.js
+++ b/src/deploy/js/osint.js
@@ -266,14 +266,14 @@ function osint()
         }
         this.ctx.putImageData(this.imageData, 0, 0);
     }
-    this.init = function( vecx )
+    this.init = function( vecx, canv )
     {
         this.vecx = vecx;
         this.screen_x = Globals.SCREEN_X_DEFAULT;
         this.screen_y = Globals.SCREEN_Y_DEFAULT;
         this.lPitch = this.bytes_per_pixel * this.screen_x;
         this.osint_defaults();
-        this.canvas = document.getElementById('screen');
+        this.canvas = canv;
         this.ctx = this.canvas.getContext('2d');
         this.imageData = this.ctx.getImageData(0, 0, this.screen_x, this.screen_y);
         this.data = this.imageData.data;

--- a/src/deploy/js/vecx.js
+++ b/src/deploy/js/vecx.js
@@ -856,13 +856,13 @@ function VecX()
         this.fpsTimer = setInterval(
             function()
             {
-                $("#status").text( "FPS: " +
+                vecx.status = "FPS: " +
                     ( vecx.count / ( new Date().getTime() - vecx.startTime )
                         * 1000.0 ).toFixed(2) + " (50)" +
                     ( vecx.extraTime > 0 ?
                        ( ", extra: " +
                             ( vecx.extraTime / ( vecx.count / 50 ) ).toFixed(2)
-                                + " (ms)" ) : "" ) );
+                                + " (ms)" ) : "" );
                 if( vecx.count > 500 )
                 {
                     vecx.startTime = new Date().getTime();
@@ -874,14 +874,6 @@ function VecX()
         var f = function()
         {
             if( !vecx.running ) return;
-            vecx.alg_jch0 =
-                 ( vecx.leftHeld ? 0x00 :
-                     ( vecx.rightHeld ? 0xff :
-                        0x80 ) );
-            vecx.alg_jch1 =
-                 ( vecx.downHeld ? 0x00 :
-                    ( vecx.upHeld ? 0xff :
-                        0x80 ) );
             vecx.snd_regs[14] = vecx.shadow_snd_regs14;
             vecx.vecx_emu.call( vecx, cycles, 0 );
             vecx.count++;
@@ -915,11 +907,11 @@ function VecX()
             this.vecx_emuloop();
         }
     }
-    this.main = function()
+    this.main = function( canv )
     {
-        this.osint.init( this );
+        this.osint.init( this, canv );
         this.e6809.init( this );
-        $("#status").text("Loaded.");
+        this.status = "Loaded.";
         this.vecx_reset();
         this.start();
     }
@@ -935,93 +927,17 @@ function VecX()
     {
         return this.e8910.toggleEnabled();
     }
-    this.leftHeld = false;
-    this.rightHeld = false;
-    this.upHeld = false;
-    this.downHeld = false;
+
     this.shadow_snd_regs14 = 0xff;
-    this.onkeydown = function( event )
-    {
-        var handled = true;
-        switch( event.keyCode )
-        {
-            case 37:
-            case 76:
-                this.leftHeld = true;
-                break;
-            case 38:
-            case 80:
-                this.upHeld = true;
-                break;
-            case 39:
-            case 222:
-                this.rightHeld = true;
-                break;
-            case 40:
-            case 59:
-            case 186:
-                this.downHeld = true;
-                break;
-            case 65:
-                this.shadow_snd_regs14 &= (~0x01);
-                break;
-            case 83:
-                this.shadow_snd_regs14 &= (~0x02);
-                break;
-            case 68:
-                this.shadow_snd_regs14 &= (~0x04);
-                break;
-            case 70:
-                this.shadow_snd_regs14 &= (~0x08);
-                break;
-            default:
-                handled = false;
-        }
-        if( handled && event.preventDefault )
-        {
-            event.preventDefault();
-        }
-    }
-    this.onkeyup = function( event )
-    {
-        var handled = true;
-        switch( event.keyCode )
-        {
-            case 37:
-            case 76:
-                this.leftHeld = false;
-                break;
-            case 38:
-            case 80:
-                this.upHeld = false;
-                break;
-            case 39:
-            case 222:
-                this.rightHeld = false;
-                break;
-            case 40:
-            case 59:
-            case 186:
-                this.downHeld = false;
-                break;
-            case 65:
-                this.shadow_snd_regs14 |= 0x01;
-                break;
-            case 83:
-                this.shadow_snd_regs14 |= 0x02;
-                break;
-            case 68:
-                this.shadow_snd_regs14 |= 0x04;
-                break;
-            case 70:
-                this.shadow_snd_regs14 |= 0x08;
-                break;
-            default:
-                handled = false;
-        }
-        if( handled && event.preventDefault )
-        {
-            event.preventDefault();
-        }
-    }
+
+    this.button = function(controller, button, state) {
+      var buttonVal = Math.pow(2, button);
+      buttonVal = buttonVal * Math.pow(2, controller*4);
+      state ? vecx.shadow_snd_regs14 &= ~buttonVal : vecx.shadow_snd_regs14 |= buttonVal;
+    };
+
+    this.axis = function(controller, axis, val) {
+      vecx["alg_jch"+(controller*2+axis)] = val;
+    };
+
 }

--- a/src/preprocess/e6809.js
+++ b/src/preprocess/e6809.js
@@ -91,7 +91,7 @@ function e6809()
 //    {
 //        return ( this.reg_cc / flag >> 0 ) & 1;
 //    }
-#define GETCC( flag ) ((this.reg_cc/flag>>0)&1)
+#define GETCC(flag) ((this.reg_cc/flag>>0)&1)
 
     /*
     * set a particular condition code to either 0 or 1.
@@ -104,7 +104,7 @@ function e6809()
 //        this.reg_cc &= ~flag;
 //        this.reg_cc |= value * flag;
 //    }
-#define SETCC( flag, value ) this.reg_cc=((this.reg_cc&~flag)|(value*flag))
+#define SETCC(flag,value) this.reg_cc=((this.reg_cc&~flag)|(value*flag))
 
     /* test carry */
 
@@ -175,7 +175,7 @@ function e6809()
 
         return flag;
     }
-#define TESTV( i0, i1, r ) ((((~(i0^i1))&(i0^r))>>7)&1)
+#define TESTV(i0,i1,r) ((((~(i0^i1))&(i0^r))>>7)&1)
 
 //    //static einline unsigned get_reg_d (void)
 //    this.get_reg_d = function()
@@ -244,7 +244,7 @@ function e6809()
 //        return this.vecx.read8(sp.value++);
 //        //(*sp)++;
 //    }
-#define PULL8( sp ) (this.vecx.read8(sp.value++))
+#define PULL8(sp) (this.vecx.read8(sp.value++))
 
     //static einline void push16 (unsigned *sp, unsigned data)
     this.push16 = function( sp, data )
@@ -970,7 +970,7 @@ function e6809()
         /* 0xffff when taken, 0 when not taken */
         this.reg_pc += this.sign_extend(offset) & mask;
 
-        //*cycles += 3;        
+        //*cycles += 3;
         cycles.value+=(3);
     }
 
@@ -1271,7 +1271,7 @@ function e6809()
     {
         //unsigned op;
         //unsigned cycles = 0;
-        //unsigned ea, i0, i1, r;        
+        //unsigned ea, i0, i1, r;
 
         var op = 0;
         var cycles = this.cycles;
@@ -3128,7 +3128,7 @@ function e6809()
             console.log( negstr );
         }
     }
-#endif    
+#endif
 
     this.init = function( vecx )
     {

--- a/src/preprocess/osint.js
+++ b/src/preprocess/osint.js
@@ -335,7 +335,7 @@ function osint()
         this.ctx.putImageData(this.imageData, 0, 0);
     }
 
-    this.init = function( vecx )
+    this.init = function( vecx, canv )
     {
         this.vecx = vecx;
 
@@ -347,7 +347,7 @@ function osint()
         this.osint_defaults();
 
         // Graphics
-        this.canvas = document.getElementById('screen');
+        this.canvas = canv; // DrSnuggles: get rid of fixed DOM names
         this.ctx = this.canvas.getContext('2d');
         this.imageData = this.ctx.getImageData(0, 0, this.screen_x, this.screen_y);
         this.data = this.imageData.data;

--- a/src/preprocess/vecx.js
+++ b/src/preprocess/vecx.js
@@ -19,7 +19,7 @@ function VecX()
 
     this.osint = new osint();
     this.e6809 = new e6809();
-    this.e8910 = new e8910();    
+    this.e8910 = new e8910();
 
     /* Memory */
 
@@ -38,7 +38,7 @@ function VecX()
     //unsigned snd_regs[16];
     this.snd_regs = new Array(16);
     this.e8910.init(this.snd_regs);
-    
+
     //static unsigned snd_select;
     this.snd_select = 0;
 
@@ -456,7 +456,7 @@ function VecX()
 
     //void write8 (unsigned address, unsigned char data)
     this.write8 = function( address, data )
-    {        
+    {
         address &= 0xffff;
         data &= 0xff;
 
@@ -783,7 +783,7 @@ function VecX()
                 this.vectors_draw[i].reset();
             }
         }
-        
+
         for( var i = 0; i < this.vectors_erse.length; i++ )
         {
             if( !this.vectors_erse[i] )
@@ -1041,7 +1041,7 @@ function VecX()
         index = this.vector_hash[key];
         if( index >= 0 && index < this.vector_draw_cnt )
         {
-            curVec = this.vectors_draw[index];            
+            curVec = this.vectors_draw[index];
         }
 
         if( curVec != null &&
@@ -1237,7 +1237,7 @@ function VecX()
 
             for( c = 0; c < icycles; c++ )
             {
-                //this.via_sstep0();                
+                //this.via_sstep0();
 //
 // via_sstep0 inline begin
 //
@@ -1637,14 +1637,14 @@ function VecX()
         this.fpsTimer = setInterval(
             function()
             {
-                $("#status").text(  "FPS: " +
+                vecx.status = "FPS: " +
                     ( vecx.count / ( new Date().getTime() - vecx.startTime )
                         * 1000.0 ).toFixed(2) + " (50)" +
                     ( vecx.extraTime > 0 ?
                        ( ", extra: " +
                             ( vecx.extraTime / ( vecx.count / 50 ) ).toFixed(2)
-                                + " (ms)" ) : "" ) );
-                    
+                                + " (ms)" ) : "" );
+
                 if( vecx.count > 500 )
                 {
                     vecx.startTime = new Date().getTime();
@@ -1657,7 +1657,7 @@ function VecX()
         var f = function()
         {
             if( !vecx.running ) return;
-
+            /* DrSnuggles: moved to input.js
             vecx.alg_jch0 =
                  ( vecx.leftHeld ? 0x00 :
                      ( vecx.rightHeld ? 0xff :
@@ -1667,10 +1667,10 @@ function VecX()
                  ( vecx.downHeld ? 0x00 :
                     ( vecx.upHeld ? 0xff :
                         0x80 ) );
-
+            */
             vecx.snd_regs[14] = vecx.shadow_snd_regs14;
 
-            vecx.vecx_emu.call( vecx, cycles, 0 );            
+            vecx.vecx_emu.call( vecx, cycles, 0 );
             vecx.count++;
 
             var now = new Date().getTime();
@@ -1678,7 +1678,7 @@ function VecX()
             vecx.extraTime += waitTime;
             if( waitTime < -EMU_TIMER ) waitTime = -EMU_TIMER;
 
-            vecx.nextFrameTime = now + EMU_TIMER + waitTime;            
+            vecx.nextFrameTime = now + EMU_TIMER + waitTime;
 
             setTimeout( function() { f(); }, waitTime );
         };
@@ -1710,12 +1710,12 @@ function VecX()
         }
     }
 
-    this.main = function()
+    this.main = function( canv )
     {
-        this.osint.init( this );
+        this.osint.init( this, canv );  // DrSnuggles: need to pass reference to canvas
         this.e6809.init( this );
 
-        $("#status").text("Loaded.");
+        this.status = "Loaded.";
 
         /* message loop handler and emulator code */
         /* reset the vectrex hardware */
@@ -1732,17 +1732,32 @@ function VecX()
         var vecx = this;
         setTimeout( function() { vecx.start(); }, 200 );
     }
-    
-    this.toggleSoundEnabled = function() 
+
+    this.toggleSoundEnabled = function()
     {
         return this.e8910.toggleEnabled();
     }
 
+    this.shadow_snd_regs14 = 0xff;
+
+    // DrSnuggles: used by input.js
+    this.button = function(controller, button, state) {
+      var buttonVal = Math.pow(2, button);
+      buttonVal = buttonVal * Math.pow(2, controller*4);
+      state ? vecx.shadow_snd_regs14 &= ~buttonVal : vecx.shadow_snd_regs14 |= buttonVal;
+    };
+
+    this.axis = function(controller, axis, val) {
+      // controller 0 = player1
+      // axis 0 = left/right
+      vecx["alg_jch"+(controller*2+axis)] = val;
+    };
+
+    /* DrSnuggles: moved to input.js
     this.leftHeld = false;
     this.rightHeld = false;
     this.upHeld = false;
     this.downHeld = false;
-    this.shadow_snd_regs14 = 0xff;
 
     this.onkeydown = function( event )
     {
@@ -1839,7 +1854,7 @@ function VecX()
             event.preventDefault();
         }
     }
-
+    */
 #if 0
     this.validateState = function()
     {
@@ -2119,7 +2134,7 @@ function VecX()
 
         if( negstr != null ) alert( negstr );
     }
-#endif    
+#endif
 }
 
 //Globals.vecx = new VecX();


### PR DESCRIPTION
Hi raz0red,

i seperated the emulator from UI specific DOM names and events.

Changes:
1.) The canvas is now a parameter when calling vecx.main passed to osint.init.
2.) The status is an attribute of vecx which is polled from index.html.
3.) The keyhandler moved to input.js and in vecx there are two new functions for settings Vectrex controller inputs (axis and button.
4.) Removed spaces in the macro defines which gulp-c-preprocessor doesn't like.

DrSnuggles